### PR TITLE
Fixes malformed url problem querying etcd

### DIFF
--- a/lib/hiera/backend/etcd_backend.rb
+++ b/lib/hiera/backend/etcd_backend.rb
@@ -20,6 +20,10 @@ class Hiera
 
         paths.each do |path|
           Hiera.debug("[hiera-etcd]: Lookup #{path}/#{key} on #{@config[:host]}:#{@config[:port]}")
+          if "#{path}/#{key}".match("//")
+            Hiera.debug("[hiera-etcd]: The specified path #{path}/#{key} is malformed, skipping")
+            next
+          end
           begin
             result = @client.get("#{path}/#{key}")
           rescue


### PR DESCRIPTION
This fixes a problem in which a malformed path lookup in etcd could return negative results if a key is found in a subsequent path.

Way to reproduce
1. Edit hiera.yaml and add a path with a variable that doesn't exist or malformed
   
   :http:
     :host: 127.0.0.1
     :port: 4001
     :paths:
       - /configuration/defaults
       - /configuration/%{fqdn}
       - /configuration/%{environmentfake}
       - /configuration/common
2. Perform a hiera lookup into etcd, for a key, if they key is available under /configuration/common/keyname it won't be found as the previous paths had variables that didn't expand and ended up with "//"

Another way to solve the issue would be to deduplicate the "//" into "/" but that would have unpredictable results
