### PR TITLE
Attempt to parse json hash or array when called with hiera()

### DIFF
--- a/lib/hiera/backend/etcd_backend.rb
+++ b/lib/hiera/backend/etcd_backend.rb
@@ -42,6 +42,7 @@ class Hiera
         answer = nil
         case type
         when :array
+          # Called with hiera_array().
           answer ||= []
           begin
             data = Backend.parse_answer(JSON[res], scope)
@@ -56,6 +57,7 @@ class Hiera
             Hiera.warn("Data is in json format, but this is not an array")
           end
         when :hash
+          # Called with hiera_hash().
           answer ||= {}
           begin
             data = Backend.parse_answer(JSON[res], scope)
@@ -69,6 +71,8 @@ class Hiera
             Hiera.warn("Data is in json format, but this is not an hash")
           end
         else
+          # Called with hiera(), which can return an array, hash, or string.
+          res = JSON[res] rescue res
           answer = Backend.parse_answer(res, scope)
         end
         answer


### PR DESCRIPTION
Attempt to parse a string as json when called by hiera() to
improve hiera-etcd compatibility with yaml backend. Fall back
to native string if the string does not contain json.

Use case:

It should be possible to use both etcd and yaml backends with
a given puppet repo and the hiera() function to return a complex
data structure.
- hiera() returns first match and can be an array, hash, or string
- hiera_array() does a concat and may not be desired
- hiera_hash() does a deep merge and may not be desired
