### PR TITLE
Accept SSL configuration & Cast some results.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,8 @@
+# Changelog #
+
+## 2016-10-16 John Anderson <ja391045@gmail.com> ##
+
+- Added SSL configuration options to etcd client connection.
+- Added a feeble attempt at casting etcd output to specific types based on content.
+    - "true" or "false" strings are cast to Puppet boolean values.
+    - "^[0-9]+$" strings are cast to Fixnum.

--- a/README.md
+++ b/README.md
@@ -20,6 +20,30 @@ The following hiera.yaml should get you started.
         - /configuration/%{fqdn}
         - /configuration/common
 
+## SSL Configuration
+
+    :backends:
+      - etcd
+
+    :http:
+      :host: 127.0.0.1
+      :port: 2379
+      :use_ssl: true
+      :ssl_ca_cert: /etc/pki/ca-trust/extracted/pem/tls-ca-bundle.pem
+
+## SSL Configuration with Client Authentication
+
+    :backends:
+      - etcd
+
+    :http:
+      :host: 127.0.0.1
+      :port: 2379
+      :use_ssl: true
+      :ssl_ca_cert: /etc/pki/ca-trust/extracted/pem/tls-ca-bundle.pem
+      :ssl_cert: /etc/pki/tls/certs/localhost.crt
+      :ssl_key: /etc/pki/tls/private/localhost.key
+ 
 
 ## Thanks
 


### PR DESCRIPTION
I needed an etcd backend to do SSL, so I grabbed this one and made a few tweaks.

I also ran into some places where Puppet would be expecting a Boolean or Fixnum value, but all that would return from etcd are strings.  This is particularly a problem when trying to use hiera-etcd for automatic parameter lookups, given the new typeability of Puppet parameters.  So I added some very generic casts for simple values that seem to "Work For Me(TM)" at the moment.  I'd like to further explore how to return appropriate types, as well as pull multiple sub-keys into a hash or array.